### PR TITLE
Increase event queue size

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -95,7 +95,7 @@ static uint32_t _closed_index = []() {
 
 static inline bool _init_async_event_queue(){
     if(!_async_queue){
-        _async_queue = xQueueCreate(32, sizeof(lwip_event_packet_t *));
+        _async_queue = xQueueCreate(CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE, sizeof(lwip_event_packet_t *));
         if(!_async_queue){
             return false;
         }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -35,7 +35,7 @@ extern "C" {
 //#define CONFIG_ASYNC_TCP_DIAGNOSTICS 1
 
 #ifndef CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE
-#define CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE (CONFIG_LWIP_MAX_ACTIVE_TCP * 2)
+#define CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE (CONFIG_LWIP_MAX_ACTIVE_TCP * 4)
 #endif
 
 //If core is not defined, then we are running in Arduino or PIO


### PR DESCRIPTION
I'm working on stabilizing ESPAsyncWebServer for WLED, and I ran in to a problem with AsyncTCP deadlocking under load (>5 inbound connections).   The issue turned out to be that the event queue overflowed, resulting in the lwip task blocking to put something in the queue, while the async service task was in turn blocked waiting for lwip to service a synchronous tcpip_api_call().

Since there doesn't seem to be a reasonable way to handle a queue overflow in this architecture -- discarding the overflowing event could confuse the state machine, resulting in leaked objects and connections -- I've oped to increase the queue size until it's big enough that I can fill service `CONFIG_LWIP_MAX_ACTIVE_TCP` connections without locking up.  Empirical testing suggested this seemed to work well at 4 events per connection.

This patch set restores the existing CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE to operation, and then increases the default size.